### PR TITLE
remove manifest.xml because it seems to break things like rospack and…

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -1,6 +1,0 @@
-<package>
-  <description brief="rttlua completion support"></description>
-  <author>Markus Klotzbuecher, markus.klotzbuecher@mech.kuleuven.be</author>
-  <license>MIT</license>
-  <review status="unreviewed" notes=""/>
-</package>


### PR DESCRIPTION
… rosdep.

Especially in a catkin environment, manifest.xml is unnecessary and negatively affects tooling.
